### PR TITLE
Bump addressable from 2.8.x to 2.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ambit (0.13)
     ast (2.4.3)

--- a/samples/round_info/Gemfile.lock
+++ b/samples/round_info/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (4.0.1)
@@ -53,7 +53,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_hal_middleware (0.1.1)
       faraday_middleware (>= 0.9)
     faraday_middleware (1.2.1)
@@ -79,7 +79,7 @@ GEM
     nokogiri (1.19.2-x86_64-linux-gnu)
       racc (~> 1.4)
     prism (1.9.0)
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
@@ -97,6 +97,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/samples/team_info/Gemfile.lock
+++ b/samples/team_info/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     dotenv (3.2.0)
     faraday (1.10.5)
@@ -26,7 +26,7 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
+    faraday-retry (1.0.4)
     faraday_hal_middleware (0.1.1)
       faraday_middleware (>= 0.9)
     faraday_middleware (1.2.1)
@@ -37,7 +37,7 @@ GEM
       faraday_hal_middleware
       faraday_middleware
     multipart-post (2.4.1)
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     ruby2_keywords (0.0.5)
 
 PLATFORMS


### PR DESCRIPTION
Combines Dependabot PRs #116, #117, #118.

Bumps [addressable](https://github.com/sporkmonger/addressable) from 2.8.x to 2.9.0 in the root and both samples.

Closes #116, closes #117, closes #118.