### PR TITLE
Raise descriptive error when Slack OAuth returns ok: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Added `check_stripe_subscribers!` cron to reconcile Stripe subscriptions with teams - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/03/29: Added `stats [yearly|monthly|quarterly]` to show S'Up stats broken down by time period, with gaps shown for periods with no S'Ups - [@dblock](https://github.com/dblock).
 * 2026/03/29: Limited `stats monthly` to the last year and `stats quarterly` to the last 3 years - [@dblock](https://github.com/dblock).

--- a/lib/api/endpoints/teams_endpoint.rb
+++ b/lib/api/endpoints/teams_endpoint.rb
@@ -51,6 +51,9 @@ module Api
 
           rc = client.send(SlackRubyBotServer.config.oauth_access_method, options)
 
+          raise rc['error'] || 'invalid OAuth response' unless rc['ok']
+          raise 'Enterprise Grid is not supported.' if rc['ok'] && rc['team'].nil?
+
           token = nil
           access_token = nil
           user_id = nil

--- a/spec/api/endpoints/teams_endpoint_spec.rb
+++ b/spec/api/endpoints/teams_endpoint_spec.rb
@@ -90,6 +90,7 @@ describe Api::Endpoints::TeamsEndpoint do
     context 'register' do
       before do
         oauth_access = {
+          'ok' => true,
           'access_token' => 'token',
           'token_type' => 'bot',
           'bot_user_id' => 'bot_user_id',
@@ -163,6 +164,55 @@ describe Api::Endpoints::TeamsEndpoint do
         expect { client.teams._post(code: 'code') }.to raise_error Faraday::ClientError do |e|
           json = JSON.parse(e.response[:body])
           expect(json['message']).to eq "Team #{existing_team.name} is already registered."
+        end
+      end
+
+      context 'when oauth returns an error' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(
+            'ok' => false,
+            'error' => 'invalid_code'
+          )
+        end
+
+        it 'raises the error' do
+          expect { client.teams._post(code: 'bad_code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'invalid_code'
+          end
+        end
+      end
+
+      context 'when oauth returns ok: false without an error message' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(
+            'ok' => false
+          )
+        end
+
+        it 'raises an invalid OAuth response error' do
+          expect { client.teams._post(code: 'bad_code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'invalid OAuth response'
+          end
+        end
+      end
+
+      context 'when oauth returns an enterprise grid response without a team' do
+        before do
+          allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(
+            'ok' => true,
+            'access_token' => 'xoxb-enterprise',
+            'team' => nil,
+            'enterprise' => { 'id' => 'E123', 'name' => 'My Enterprise' }
+          )
+        end
+
+        it 'raises an enterprise not supported error' do
+          expect { client.teams._post(code: 'code') }.to raise_error Faraday::ClientError do |e|
+            json = JSON.parse(e.response[:body])
+            expect(json['message']).to eq 'Enterprise Grid is not supported.'
+          end
         end
       end
 

--- a/spec/integration/teams_spec.rb
+++ b/spec/integration/teams_spec.rb
@@ -17,6 +17,7 @@ describe 'Teams', :js, type: :feature do
       allow_any_instance_of(Team).to receive(:ping!).and_return(ok: true)
       expect(SlackRubyBotServer::Service.instance).to receive(:start!)
       oauth_access = {
+        'ok' => true,
         'access_token' => 'token',
         'token_type' => 'bot',
         'bot_user_id' => 'bot_user_id',


### PR DESCRIPTION
## What

When Slack's `oauth.v2.access` returns an error response (e.g. `invalid_code`, `bad_client_secret`), the code was crashing with a `NoMethodError` at `rc['team']['id']` because `rc['team']` is `nil` in error responses.

## Why

The OAuth callback handler never checked `rc['ok']` before accessing nested fields, so any Slack error response (expired/reused code, bad credentials, etc.) caused an unhandled nil dereference instead of a clean error.

## How

Added `raise rc['error'] unless rc['ok']` immediately after the OAuth API call. Also added `'ok' => true` to the existing test mock (matching real Slack API responses) and a new test covering the error path.