### PR TITLE
Throttle past due subscription notifications to once every 72 hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changelog
 
+* 2026/05/03: Throttle past due subscription notifications to at most once every 72 hours - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/20: Raise a descriptive error when Slack OAuth returns `ok: false`, or when an Enterprise Grid install is attempted - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/04/19: Added `check_stripe_subscribers!` cron to reconcile Stripe subscriptions with teams - [@dblock](https://github.com/dblock), [@Copilot](https://github.com/apps/copilot-swe-agent).
 * 2026/03/29: Added `stats [yearly|monthly|quarterly]` to show S'Up stats broken down by time period, with gaps shown for periods with no S'Ups - [@dblock](https://github.com/dblock).

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -190,12 +190,15 @@ module SlackSup
           logger.info "Checking #{team} subscription to #{subscription_name}, #{subscription.status}."
           case subscription.status
           when 'past_due'
+            next if team.past_due_informed_at && Time.now.utc < team.past_due_informed_at + 72.hours
+
             logger.warn "Subscription for #{team} is #{subscription.status}, notifying."
             team.inform! "Your subscription to #{subscription_name} is past due. #{team.update_cc_text}"
+            team.update_attributes!(past_due_informed_at: Time.now.utc)
           when 'canceled', 'unpaid'
             logger.warn "Subscription for #{team} is #{subscription.status}, downgrading."
             team.inform! "Your subscription to #{subscription.plan.name} (#{ActiveSupport::NumberHelper.number_to_currency(subscription.plan.amount.to_f / 100)}) was canceled and your team has been downgraded. Thank you for being a customer!"
-            team.update_attributes!(subscribed: false)
+            team.update_attributes!(subscribed: false, past_due_informed_at: nil)
           end
         end
         if customer.subscriptions.none?

--- a/lib/models/team.rb
+++ b/lib/models/team.rb
@@ -5,6 +5,7 @@ class Team
   field :stripe_customer_id, type: String
   field :subscribed, type: Boolean, default: false
   field :subscribed_at, type: DateTime
+  field :past_due_informed_at, type: DateTime
 
   scope :api, -> { where(api: true) }
 

--- a/spec/slack-sup/app_spec.rb
+++ b/spec/slack-sup/app_spec.rb
@@ -75,14 +75,34 @@ describe SlackSup::App do
         allow_any_instance_of(Team).to receive(:short_lived_token).and_return('token')
         expect_any_instance_of(Team).to receive(:inform!).with("Your subscription to StripeMock Default Plan ID ($39.99) is past due. #{team.update_cc_text}")
         subject.send(:check_subscribed_teams!)
+        expect(team.reload.past_due_informed_at).not_to be_nil
       end
 
-      it 'notifies past due subscription' do
+      it 'does not re-notify past due subscription within 72 hours' do
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
+        customer.subscriptions.data.first['status'] = 'past_due'
+        expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
+        expect_any_instance_of(Team).not_to receive(:inform!)
+        subject.send(:check_subscribed_teams!)
+      end
+
+      it 'notifies past due subscription again after 72 hours' do
+        team.update_attributes!(past_due_informed_at: 73.hours.ago)
+        customer.subscriptions.data.first['status'] = 'past_due'
+        expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
+        allow_any_instance_of(Team).to receive(:short_lived_token).and_return('token')
+        expect_any_instance_of(Team).to receive(:inform!).with("Your subscription to StripeMock Default Plan ID ($39.99) is past due. #{team.update_cc_text}")
+        subject.send(:check_subscribed_teams!)
+      end
+
+      it 'notifies canceled subscription' do
         customer.subscriptions.data.first['status'] = 'canceled'
+        team.update_attributes!(past_due_informed_at: 1.hour.ago)
         expect(Stripe::Customer).to receive(:retrieve).and_return(customer)
         expect_any_instance_of(Team).to receive(:inform!).with('Your subscription to StripeMock Default Plan ID ($39.99) was canceled and your team has been downgraded. Thank you for being a customer!')
         subject.send(:check_subscribed_teams!)
         expect(team.reload.subscribed?).to be false
+        expect(team.reload.past_due_informed_at).to be_nil
       end
 
       it 'notifies no active subscriptions' do


### PR DESCRIPTION
Adds a `past_due_informed_at` field to `Team`. When a subscription is `past_due`, the notification is only sent if no notification has been sent in the past 72 hours. The field is cleared when the subscription is canceled/downgraded.
